### PR TITLE
utils.bash: treat aarch64 as aarch64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -38,7 +38,7 @@ get_arch() {
   amd64 | x86_64)
     echo "x86_64"
     ;;
-  arm64)
+  arm64 | aarch64)
     echo "aarch64"
     ;;
   *)


### PR DESCRIPTION
Seeing this in CircleCI arm.xlarge images.